### PR TITLE
Fix segmentation quantified objects when processing PDF documents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,12 +41,12 @@ tasks.withType(JavaCompile).configureEach {
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "11"
     }
 }
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "11"
     }
 }
 
@@ -253,12 +253,12 @@ task integration(type: Test) {
     }
 
     if (JavaVersion.current().compareTo(JavaVersion.VERSION_1_8) > 0) {
-//        jvmArgs "--add-opens", "java.base/java.util.stream=ALL-UNNAMED",
-//            "--add-opens", "java.base/java.io=ALL-UNNAMED",
-//            "--add-opens", "java.base/java.lang=ALL-UNNAMED",
-//            "--add-opens", "java.base/java.util.regex=ALL-UNNAMED",
-//            "--add-opens", "java.base/java.math=ALL-UNNAMED",
-//            "--add-opens", "java.base/java.text=ALL-UNNAMED"
+        jvmArgs "--add-opens", "java.base/java.util.stream=ALL-UNNAMED",
+            "--add-opens", "java.base/java.io=ALL-UNNAMED",
+            "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+            "--add-opens", "java.base/java.util.regex=ALL-UNNAMED",
+            "--add-opens", "java.base/java.math=ALL-UNNAMED",
+            "--add-opens", "java.base/java.text=ALL-UNNAMED"
     }
     systemProperty "java.library.path", "${System.getProperty('java.library.path')}:" + libraries
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,12 +41,12 @@ tasks.withType(JavaCompile).configureEach {
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 }
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 }
 
@@ -74,14 +74,20 @@ repositories {
 
 dependencies {
     //Tests
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.9.3'
-    testImplementation(platform('org.junit:junit-bom:5.9.3'))
+    testImplementation(platform('org.junit:junit-bom:5.10.2'))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher") {
+        because("Only needed to run tests in a version of IntelliJ IDEA that bundles older versions")
+    }
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
     testImplementation('org.junit.jupiter:junit-jupiter')
-    testImplementation 'org.easymock:easymock:5.1.0'
+    
+    testImplementation 'org.easymock:easymock:5.2.0'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
     testImplementation 'org.powermock:powermock-api-easymock:2.0.9'
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
+    
     //GROBID
     implementation 'org.grobid:grobid-core:0.8.0'
     implementation 'org.grobid:grobid-trainer:0.8.0'
@@ -176,7 +182,7 @@ test {
 
     def libraries = ""
     if (Os.isFamily(Os.FAMILY_MAC)) {
-        if (Os.OS_ARCH.equals("aarch64")) {
+        if (Os.isArch("aarch64")) {
             libraries = "${file("./grobid-home/lib/mac_arm-64").absolutePath}"
         } else {
             libraries = "${file("./grobid-home/lib/mac-64").absolutePath}"
@@ -210,7 +216,7 @@ run {
 
     def libraries = ""
     if (Os.isFamily(Os.FAMILY_MAC)) {
-        if (Os.OS_ARCH.equals("aarch64")) {
+        if (Os.isArch("aarch64")) {
             libraries = "${file("../grobid-home/lib/mac_arm-64").absolutePath}"
         } else {
             libraries = "${file("../grobid-home/lib/mac-64").absolutePath}"
@@ -238,7 +244,7 @@ task integration(type: Test) {
 
     def libraries = ""
     if (Os.isFamily(Os.FAMILY_MAC)) {
-        if (Os.OS_ARCH.equals("aarch64")) {
+        if (Os.isArch("aarch64")) {
             libraries = "${file("./grobid-home/lib/mac_arm-64").absolutePath}"
         } else {
             libraries = "${file("./grobid-home/lib/mac-64").absolutePath}"

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
     testImplementation 'org.powermock:powermock-api-easymock:2.0.9'
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
+    testImplementation "io.mockk:mockk:1.13.9"
     
     //GROBID
     implementation 'org.grobid:grobid-core:0.8.0'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,6 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
     testImplementation 'org.powermock:powermock-api-easymock:2.0.9'
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
-
     //GROBID
     implementation 'org.grobid:grobid-core:0.8.0'
     implementation 'org.grobid:grobid-trainer:0.8.0'
@@ -379,6 +378,10 @@ task downloadTransformers(dependsOn: copyModels) {
 
 wrapper {
     gradleVersion "7.2"
+}
+
+test {
+    useJUnitPlatform()
 }
 
 jacocoTestReport {

--- a/src/main/java/org/grobid/core/data/SentenceParse.java
+++ b/src/main/java/org/grobid/core/data/SentenceParse.java
@@ -12,6 +12,7 @@ import com.googlecode.clearnlp.headrule.HeadRuleMap;
 import com.googlecode.clearnlp.morphology.AbstractMPAnalyzer;
 import com.googlecode.clearnlp.morphology.EnglishMPAnalyzer;
 import com.googlecode.clearnlp.util.UTInput;
+import org.apache.commons.lang3.StringUtils;
 import org.grobid.core.analyzers.QuantityAnalyzer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -278,13 +279,13 @@ public class SentenceParse {
     public String getTokenStructureByPosition(int position) {
         if (tokenStructures == null)
             return null;
-        return tokenStructures.get(valueOf(position));
+        return tokenStructures.get(position);
     }
 
     public String getTokenStructureByIndex(String index) {
         if (tokenIndex == null)
             return null;
-        if ( (index == null) || (index.length() == 0) )
+        if (StringUtils.isEmpty(index))
             return null;
         return tokenIndex.get(index);
     }

--- a/src/main/java/org/grobid/core/data/normalization/QuantityNormalizer.java
+++ b/src/main/java/org/grobid/core/data/normalization/QuantityNormalizer.java
@@ -197,7 +197,8 @@ public class QuantityNormalizer {
                                 javax.measure.Unit<?> onlyUnitParsed = formatService.parse(onlyUnit);
                                 unitList.add(onlyUnitParsed.pow(-1));
                             } catch (Throwable e2) {
-                                LOGGER.warn("Trying excluding the negative power. Cannot parse " + onlyUnit + " with " + formatService.getClass().getName(), e2);
+                                LOGGER.warn("Trying excluding the negative power. Cannot parse " + onlyUnit + " with " + formatService.getClass().getName());
+                                LOGGER.debug("Exception", e2);
                             }
                             break;
                         }

--- a/src/main/java/org/grobid/core/engines/DefaultQuantifiedObjectParser.java
+++ b/src/main/java/org/grobid/core/engines/DefaultQuantifiedObjectParser.java
@@ -36,7 +36,11 @@ public class DefaultQuantifiedObjectParser extends QuantifiedObjectParser {
         try {
             String text = LayoutTokensUtil.toText(tokens);
             TextParser textParser = TextParser.getInstance();
-            List<Sentence> parsedSentences = textParser.parseText(text);
+            int firstOffset = Iterables.getFirst(tokens, new LayoutToken()).getOffset();
+            List<OffsetPosition> measurementsOffsets = measurements.stream()
+                .map(m -> new OffsetPosition(m.getRawOffsets().start - firstOffset, m.getRawOffsets().end - firstOffset))
+                .collect(Collectors.toList());
+            List<Sentence> parsedSentences = textParser.parseText(text, measurementsOffsets);
             int firstTokenOffsetStart = tokens.get(0).getOffset();
             parsedSentences.stream().forEach(s -> {
                 s.getOffset().start = s.getOffsetStart() + firstTokenOffsetStart;

--- a/src/main/java/org/grobid/core/engines/DefaultQuantifiedObjectParser.java
+++ b/src/main/java/org/grobid/core/engines/DefaultQuantifiedObjectParser.java
@@ -377,7 +377,7 @@ public class DefaultQuantifiedObjectParser extends QuantifiedObjectParser {
         return result;
     }
 
-    private void addTokenIndex(int position, int length, SentenceParse parse, List<String> result) {
+    protected List<String> addTokenIndex(int position, int length, SentenceParse parse, List<String> result) {
         String tokenStruct = parse.getTokenStructureByPosition(position);
         if (tokenStruct != null) {
             String[] pieces = tokenStruct.split("\t");
@@ -405,6 +405,8 @@ public class DefaultQuantifiedObjectParser extends QuantifiedObjectParser {
                 }
             }
         }
+        
+        return result;
     }
 
     private String getNextStruct(int position, List<String> indexMeasurementTokens, int sentenceLength, SentenceParse parse) {

--- a/src/main/java/org/grobid/core/engines/QuantitiesEngine.java
+++ b/src/main/java/org/grobid/core/engines/QuantitiesEngine.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterables;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.core.Response;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
@@ -19,36 +22,30 @@ import org.grobid.core.engines.label.SegmentationLabels;
 import org.grobid.core.engines.label.TaggingLabels;
 import org.grobid.core.layout.LayoutToken;
 import org.grobid.core.layout.LayoutTokenization;
-import org.grobid.core.lexicon.QuantityLexicon;
 import org.grobid.core.tokenization.LabeledTokensContainer;
 import org.grobid.core.tokenization.TaggingTokenCluster;
 import org.grobid.core.tokenization.TaggingTokenClusteror;
 import org.grobid.core.utilities.GrobidProperties;
 import org.grobid.core.utilities.IOUtilities;
+import org.grobid.core.utilities.UnicodeUtil;
 import org.grobid.core.utilities.UnitUtilities;
 import org.grobid.service.exceptions.GrobidServiceException;
-import org.grobid.trainer.UnitLabeled;
-import org.grobid.trainer.sax.UnitAnnotationSaxHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
-import jakarta.ws.rs.core.Response;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.SortedSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 /**
@@ -124,7 +121,7 @@ public class QuantitiesEngine {
                 List<LayoutToken> tokenizationHeader = headerStruct.getRight();//doc.getTokenizationParts(documentParts, doc.getTokenizations());
                 String header = headerStruct.getLeft();
                 String labeledResult = null;
-                if ((header != null) && (header.trim().length() > 0)) {
+                if (StringUtils.isNotBlank(StringUtils.trimToEmpty(header))) {
                     labeledResult = parsers.getHeaderParser().label(header);
 
                     BiblioItem resHeader = new BiblioItem();
@@ -134,19 +131,19 @@ public class QuantitiesEngine {
                     // title
                     List<LayoutToken> titleTokens = resHeader.getLayoutTokens(TaggingLabels.HEADER_TITLE);
                     if (titleTokens != null) {
-                        measurements.addAll(quantityParser.process(titleTokens));
+                        measurements.addAll(quantityParser.process(normaliseAndCleanup(titleTokens)));
                     }
 
                     // abstract
                     List<LayoutToken> abstractTokens = resHeader.getLayoutTokens(TaggingLabels.HEADER_ABSTRACT);
                     if (abstractTokens != null) {
-                        measurements.addAll(quantityParser.process(abstractTokens));
+                        measurements.addAll(quantityParser.process(normaliseAndCleanup(abstractTokens)));
                     }
 
                     // keywords
                     List<LayoutToken> keywordTokens = resHeader.getLayoutTokens(TaggingLabels.HEADER_KEYWORD);
                     if (keywordTokens != null) {
-                        measurements.addAll(quantityParser.process(keywordTokens));
+                        measurements.addAll(quantityParser.process(normaliseAndCleanup(keywordTokens)));
                     }
                 }
             }
@@ -179,11 +176,11 @@ public class QuantitiesEngine {
                             //apply the figure model to only get the caption
                             final Figure processedFigure = parsers.getFigureParser()
                                 .processing(cluster.concatTokens(), cluster.getFeatureBlock());
-                            measurements.addAll(quantityParser.process(processedFigure.getCaptionLayoutTokens()));
+                            measurements.addAll(quantityParser.process(normaliseAndCleanup(processedFigure.getCaptionLayoutTokens())));
                         } else if (cluster.getTaggingLabel().equals(TaggingLabels.TABLE)) {
                             //apply the table model to only get the caption/description
                             final List<Table> processedTable = parsers.getTableParser().processing(cluster.concatTokens(), cluster.getFeatureBlock());
-                            processedTable.stream().forEach(t -> measurements.addAll(quantityParser.process(t.getFullDescriptionTokens())));
+                            processedTable.stream().forEach(t -> measurements.addAll(quantityParser.process(normaliseAndCleanup(t.getFullDescriptionTokens()))));
 
                         } else {
                             final List<LabeledTokensContainer> labeledTokensContainers = cluster.getLabeledTokensContainers();
@@ -194,7 +191,7 @@ public class QuantitiesEngine {
                                 .flatMap(List::stream)
                                 .collect(Collectors.toList());
 
-                            measurements.addAll(quantityParser.process(tokens));
+                            measurements.addAll(quantityParser.process(normaliseAndCleanup(tokens)));
                         }
 
                     }
@@ -418,5 +415,55 @@ public class QuantitiesEngine {
                 IOUtils.closeQuietly(outputWriter);
             }
         }
+    }
+
+    /**
+     * Transform break lines in spaces and remove duplicated spaces
+     */
+    protected static List<LayoutToken> normaliseAndCleanup(List<LayoutToken> layoutTokens) {
+        if (isEmpty(layoutTokens)) {
+            return new ArrayList<>();
+        }
+
+        //De-hypenisation and converting break lines with spaces.
+        List<LayoutToken> bodyLayouts = layoutTokens
+            .stream()
+            .map(m -> {
+                m.setText(StringUtils.replace(m.getText(), "\r\n", " "));
+                m.setText(StringUtils.replace(m.getText(), "\n", " "));
+                m.setText(UnicodeUtil.normaliseText(m.getText()).replaceAll("\\p{C}", " "));
+                return m;
+            })
+            .collect(Collectors.toList());
+
+        //Removing duplicated spaces
+        /*List<LayoutToken> cleanedTokens = IntStream
+            .range(0, bodyLayouts.size())
+            .filter(i -> {
+                    if (i < bodyLayouts.size() - 1) {
+                        if (bodyLayouts.get(i).getText().equals("\n") || bodyLayouts.get(i).getText().equals(" ")) {
+                            return !StringUtils.equals(bodyLayouts.get(i).getText(), bodyLayouts.get(i + 1).getText());
+                        }
+                    }
+                    return true;
+                }
+            )
+            .mapToObj(bodyLayouts::get)
+            .collect(Collectors.toList());*/
+
+        // Correcting offsets after having removed certain tokens
+/*        IntStream
+            .range(1, cleanedTokens.size())
+            .forEach(i -> {
+                int expectedFollowingOffset = cleanedTokens.get(i - 1).getOffset()
+                    + StringUtils.length(cleanedTokens.get(i - 1).getText());
+
+                if (expectedFollowingOffset != cleanedTokens.get(i).getOffset()) {
+                    LOGGER.trace("Correcting offsets " + i + " from " + cleanedTokens.get(i).getOffset() + " to " + expectedFollowingOffset);
+                    cleanedTokens.get(i).setOffset(expectedFollowingOffset);
+                }
+            });*/
+
+        return bodyLayouts;
     }
 }

--- a/src/main/java/org/grobid/core/engines/QuantitiesEngine.java
+++ b/src/main/java/org/grobid/core/engines/QuantitiesEngine.java
@@ -231,7 +231,7 @@ public class QuantitiesEngine {
         // List<LayoutToken> for the selected segment
         List<LayoutToken> layoutTokens
             = doc.getTokenizationParts(documentParts, doc.getTokenizations());
-        return quantityParser.process(layoutTokens);
+        return quantityParser.process(normaliseAndCleanup(layoutTokens));
     }
 
     public List<Measurement> parseMeasurement(String json) {

--- a/src/main/java/org/grobid/core/engines/QuantitiesEngine.java
+++ b/src/main/java/org/grobid/core/engines/QuantitiesEngine.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -437,7 +438,7 @@ public class QuantitiesEngine {
             .collect(Collectors.toList());
 
         //Removing duplicated spaces
-        /*List<LayoutToken> cleanedTokens = IntStream
+        List<LayoutToken> cleanedTokens = IntStream
             .range(0, bodyLayouts.size())
             .filter(i -> {
                     if (i < bodyLayouts.size() - 1) {
@@ -449,10 +450,10 @@ public class QuantitiesEngine {
                 }
             )
             .mapToObj(bodyLayouts::get)
-            .collect(Collectors.toList());*/
+            .collect(Collectors.toList());
 
         // Correcting offsets after having removed certain tokens
-/*        IntStream
+        IntStream
             .range(1, cleanedTokens.size())
             .forEach(i -> {
                 int expectedFollowingOffset = cleanedTokens.get(i - 1).getOffset()
@@ -462,8 +463,8 @@ public class QuantitiesEngine {
                     LOGGER.trace("Correcting offsets " + i + " from " + cleanedTokens.get(i).getOffset() + " to " + expectedFollowingOffset);
                     cleanedTokens.get(i).setOffset(expectedFollowingOffset);
                 }
-            });*/
+            });
 
-        return bodyLayouts;
+        return cleanedTokens;
     }
 }

--- a/src/main/java/org/grobid/core/engines/QuantityParser.java
+++ b/src/main/java/org/grobid/core/engines/QuantityParser.java
@@ -812,7 +812,7 @@ public class QuantityParser extends AbstractParser {
             OffsetPosition defaultValue = new OffsetPosition(0, 0);
             return new OffsetPosition(Iterables.getFirst(sentencesCurrentMeasure, defaultValue).start, Iterables.getLast(sentencesCurrentMeasure).end);
         } else {
-            LOGGER.warn("Cannot find sentence. The entity might be inconsistent: " + currentMeasureOffset.toString());
+            LOGGER.warn("Cannot find sentence. The entity might be outside the sentence: " + currentMeasureOffset.toString());
             OffsetPosition defaultValue = new OffsetPosition(0, 0);
             return new OffsetPosition(Iterables.getFirst(sentences, defaultValue).start, Iterables.getLast(sentences).end);
         }

--- a/src/main/java/org/grobid/core/engines/QuantityParser.java
+++ b/src/main/java/org/grobid/core/engines/QuantityParser.java
@@ -795,11 +795,11 @@ public class QuantityParser extends AbstractParser {
         m.setRawString(measurementRawOffsetsAndText.getRight().replace("\n", " "));
     }
 
-    private OffsetPosition findSentenceOffset(List<OffsetPosition> sentences, OffsetPosition offsets) {
-        return findSentenceOffset(sentences, offsets);
+    protected OffsetPosition findSentenceOffset(List<OffsetPosition> sentences, OffsetPosition offsets) {
+        return findSentenceOffset(sentences, offsets, 0);
     }
 
-    private OffsetPosition findSentenceOffset(List<OffsetPosition> sentences, OffsetPosition currentMeasureOffset, int firstTokenOffset) {
+    protected OffsetPosition findSentenceOffset(List<OffsetPosition> sentences, OffsetPosition currentMeasureOffset, int firstTokenOffset) {
         List<OffsetPosition> sentencesCurrentMeasure = sentences.stream()
             .filter(sop -> sop.start <= currentMeasureOffset.start - firstTokenOffset
                 && sop.end > currentMeasureOffset.end - firstTokenOffset)
@@ -818,11 +818,11 @@ public class QuantityParser extends AbstractParser {
         }
     }
 
-    private OffsetPosition findSentenceOffset(List<OffsetPosition> sentences, Measurement measurement) {
+    protected OffsetPosition findSentenceOffset(List<OffsetPosition> sentences, Measurement measurement) {
         return findSentenceOffset(sentences, measurement, 0);
     }
 
-    private OffsetPosition findSentenceOffset(List<OffsetPosition> sentences, Measurement measurement, int firstTokenOffset) {
+    protected OffsetPosition findSentenceOffset(List<OffsetPosition> sentences, Measurement measurement, int firstTokenOffset) {
         OffsetPosition currentMeasureOffset = measurementOperations.calculateExtremitiesOffsets(measurement);
 
         return findSentenceOffset(sentences, currentMeasureOffset, firstTokenOffset);

--- a/src/main/java/org/grobid/core/engines/QuantityParser.java
+++ b/src/main/java/org/grobid/core/engines/QuantityParser.java
@@ -801,18 +801,18 @@ public class QuantityParser extends AbstractParser {
 
     private OffsetPosition findSentenceOffset(List<OffsetPosition> sentences, OffsetPosition currentMeasureOffset, int firstTokenOffset) {
         List<OffsetPosition> sentencesCurrentMeasure = sentences.stream()
-            .filter(sop -> sop.start < currentMeasureOffset.start - firstTokenOffset
+            .filter(sop -> sop.start <= currentMeasureOffset.start - firstTokenOffset
                 && sop.end > currentMeasureOffset.end - firstTokenOffset)
             .collect(Collectors.toList());
 
         if (sentencesCurrentMeasure.size() == 1) {
             return sentencesCurrentMeasure.get(0);
-        } else if (sentencesCurrentMeasure.size() > 1) {
+        } /*else if (sentencesCurrentMeasure.size() > 1) {
             LOGGER.warn("The measurement is spread along multiple sentences. We return an expanded sentence: " + currentMeasureOffset.toString());
             OffsetPosition defaultValue = new OffsetPosition(0, 0);
             return new OffsetPosition(Iterables.getFirst(sentencesCurrentMeasure, defaultValue).start, Iterables.getLast(sentencesCurrentMeasure).end);
-        } else {
-            LOGGER.warn("Cannot find sentence. The entity might be outside the sentence: " + currentMeasureOffset.toString());
+        } */else {
+//            LOGGER.warn("Cannot find sentence. The entity might be outside the sentence: " + currentMeasureOffset.toString());
             OffsetPosition defaultValue = new OffsetPosition(0, 0);
             return new OffsetPosition(Iterables.getFirst(sentences, defaultValue).start, Iterables.getLast(sentences).end);
         }

--- a/src/main/java/org/grobid/core/engines/QuantityParser.java
+++ b/src/main/java/org/grobid/core/engines/QuantityParser.java
@@ -789,7 +789,7 @@ public class QuantityParser extends AbstractParser {
         return measurements;
     }
 
-    private static void populateRawOffsetsAndText(Measurement m, List<LayoutToken> tokens) {
+    protected static void populateRawOffsetsAndText(Measurement m, List<LayoutToken> tokens) {
         final Pair<OffsetPosition, String> measurementRawOffsetsAndText = QuantityOperations.getMeasurementRawOffsetsAndText(m, tokens);
         m.setRawOffsets(measurementRawOffsetsAndText.getLeft());
         m.setRawString(measurementRawOffsetsAndText.getRight().replace("\n", " "));
@@ -803,7 +803,7 @@ public class QuantityParser extends AbstractParser {
         List<OffsetPosition> sentencesCurrentMeasure = sentences.stream()
             .filter(sop -> sop.start <= currentMeasureOffset.start - firstTokenOffset
                 && sop.end > currentMeasureOffset.end - firstTokenOffset)
-            .collect(Collectors.toList());
+            .toList();
 
         if (sentencesCurrentMeasure.size() == 1) {
             return sentencesCurrentMeasure.get(0);

--- a/src/main/java/org/grobid/core/utilities/TextParser.java
+++ b/src/main/java/org/grobid/core/utilities/TextParser.java
@@ -16,6 +16,7 @@ import com.googlecode.clearnlp.tokenization.AbstractTokenizer;
 import com.googlecode.clearnlp.util.UTInput;
 import com.googlecode.clearnlp.util.pair.Pair;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.grobid.core.data.Sentence;
 import org.grobid.core.data.SentenceParse;
 import org.grobid.core.exceptions.GrobidException;
@@ -168,16 +169,16 @@ public class TextParser {
      * semantic role labeling) as the n-best list of Parse object. If the CLEAR_PARSER is
      * selected, only the best parse is provided in the list.
      */
-    public synchronized List<Sentence> parseText(String text) throws GrobidException {
+    public synchronized List<Sentence> parseText(String text, List<OffsetPosition> measurementOffsets) throws GrobidException {
         if (text == null) {
             throw new GrobidException("Cannot parse the sentence, because it is null.");
-        } else if (text.length() == 0) {
+        } else if (StringUtils.isEmpty(text)) {
             LOGGER.error("The length of the text to be parsed is 0.");
             return null;
         }
 
         List<Sentence> results = new ArrayList<>();
-        List<OffsetPosition> sentences = this.segmenter.runSentenceDetection(text);
+        List<OffsetPosition> sentences = this.segmenter.runSentenceDetection(text, measurementOffsets);
 
         if (CollectionUtils.isEmpty(sentences)) {
             // there is some text but not in a state so that a sentence at least can be

--- a/src/main/java/org/grobid/core/utilities/TextParser.java
+++ b/src/main/java/org/grobid/core/utilities/TextParser.java
@@ -165,6 +165,8 @@ public class TextParser {
      * Parsing of some raw text.
      *
      * @param text the raw text to be parsed
+     * @param measurementOffsets cancel the segmentation if sentence boundaries are falling on a measurement 
+     *              
      * @return the list of parses - one per sentence - (including predicate identification and
      * semantic role labeling) as the n-best list of Parse object. If the CLEAR_PARSER is
      * selected, only the best parse is provided in the list.

--- a/src/test/java/org/grobid/core/utilities/TextParserIntegrationTest.java
+++ b/src/test/java/org/grobid/core/utilities/TextParserIntegrationTest.java
@@ -2,14 +2,22 @@ package org.grobid.core.utilities;
 
 import org.grobid.core.data.Sentence;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.grobid.core.engines.UnitParserIntegrationTest.initEngineForTests;
 
 @Ignore
 public class TextParserIntegrationTest {
 
     TextParser target;
 
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        initEngineForTests();
+    }
+    
     @Before
     public void setUp() throws Exception {
         target = TextParser.getInstance();

--- a/src/test/kotlin/org/grobid/core/engines/DefaultQuantifiedObjectParserTest.kt
+++ b/src/test/kotlin/org/grobid/core/engines/DefaultQuantifiedObjectParserTest.kt
@@ -1,0 +1,125 @@
+package org.grobid.core.engines;
+
+import com.googlecode.clearnlp.engine.EngineGetter
+import com.googlecode.clearnlp.tokenization.AbstractTokenizer
+import org.grobid.core.data.SentenceParse
+import org.grobid.core.utilities.GrobidConfig
+import org.grobid.core.utilities.GrobidProperties
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+
+
+class DefaultQuantifiedObjectParserTest {
+
+    private var target: DefaultQuantifiedObjectParser? = null
+
+    @BeforeEach
+    fun setUp() {
+        target = DefaultQuantifiedObjectParser()
+//        val tokenizer: AbstractTokenizer? = EngineGetter.getTokenizer("en", );
+    }
+
+    @Test
+    fun addTokenIndex() {
+        val result: List<String> = ArrayList()
+
+        val tree = """1	However	however	RB	_	12	advmod	12:AM-DIS
+2	,	,	,	_	12	punct	_
+3	upon	upon	IN	_	12	prep	12:AM-TMP
+4	closer	close	JJR	_	5	amod	_
+5	analysis	analysis	NN	_	3	pobj	_
+6	,	,	,	_	12	punct	_
+7	none	none	NN	_	12	nsubj	12:A1;15:A1
+8	of	of	IN	_	7	prep	_
+9	the	the	DT	_	11	det	_
+10	five	#crd#	CD	_	11	num	_
+11	assumptions	assumption	NNS	_	8	pobj	_
+12	are	be	VBP	pb=be.01	0	root	_
+13	ful	ful	JJ	_	15	hmod	15:A2
+14	-	-	HYPH	_	15	hyph	_
+15	filled	fill	VBN	pb=fill.01	12	acomp	_
+16	a	a	DT	_	29	det	_
+17	priori	priori	JJ	_	12	acomp	12:A2
+18	and	and	CC	_	17	cc	_
+19	,	,	,	_	17	punct	_
+20	thus	thus	RB	_	37	advmod	37:AM-ADV
+21	,	,	,	_	37	punct	_
+22	significant	significant	JJ	_	23	amod	_
+23	errors	error	NNS	_	37	nsubj	37:A1
+24	or	or	CC	_	23	cc	_
+25	misinterpretations	misinterpretation	NNS	_	23	conj	_
+26	,	,	,	_	25	punct	_
+27	e.g.	e.g.	FW	_	29	advmod	_
+28	,	,	,	_	29	punct	_
+29	overestimation	overestimation	NN	_	25	appos	_
+30	of	of	IN	_	29	prep	_
+31	the	the	DT	_	34	det	_
+32	average	average	JJ	_	34	amod	_
+33	field	field	NN	_	34	nn	_
+34	strength	strength	NN	_	30	pobj	_
+35	,	,	,	_	37	punct	_
+36	can	can	MD	_	37	aux	37:AM-MOD
+37	occur	occur	VB	pb=occur.01	17	appos	_
+38	when	when	WRB	_	41	advmod	41:R-AM-TMP
+39	apply	apply	VB	pb=apply.02	41	hmod	_
+40	-	-	HYPH	_	41	hyph	_
+41	ing	ing	VBG	pb=ing.01	37	advcl	37:AM-TMP;39:AM-TMP
+42	the	the	DT	_	45	det	_
+43	simple	simple	JJ	_	45	amod	_
+44	signal	signal	NN	_	45	nn	_
+45	model	model	NN	_	41	dobj	41:A1
+46	,	,	,	_	45	punct	_
+47	i.e.	i.e.	FW	_	50	advmod	_
+48	,	,	,	_	50	punct	_
+49	(	(	-LRB-	_	50	punct	_
+50	1	0	LS	_	54	meta	_
+51	)	)	-RRB-	_	50	punct	_
+52	to	to	TO	_	17	prep	_
+53	(	(	-LRB-	_	54	punct	_
+54	3	0	CD	_	52	parataxis	_
+55	)	)	-RRB-	_	54	punct	_
+56	.	.	.	_	12	punct	_"""
+
+        var sentence =
+            "However, upon closer analysis, none of the five assumptions are ful- filled a priori and, thus, significant errors or misinterpretations, e.g., overestimation of the average field strength, can occur when apply- ing the simple signal model, i.e., (1) to (3).";
+
+        val sentenceParse = SentenceParse()
+        sentenceParse.parseRepresentation = tree
+        sentenceParse.createMap(sentence)
+
+        var indexes = target?.addTokenIndex(0, 1, sentenceParse, ArrayList())
+
+        assertThat(indexes, hasSize(1))
+        assertThat(indexes!!.get(0), `is`("1"))
+        assertThat(sentenceParse.getTokenStructureByIndex(indexes.get(0)), startsWith("1\tHowever"))
+
+        indexes = target?.addTokenIndex(0, 7, sentenceParse, ArrayList())
+
+        assertThat(indexes, hasSize(1))
+        assertThat(indexes!!.get(0), `is`("1"))
+        assertThat(sentenceParse.getTokenStructureByIndex(indexes.get(0)), startsWith("1\tHowever"))
+
+        indexes = target?.addTokenIndex(9, 4, sentenceParse, ArrayList())
+        assertThat(indexes, hasSize(1))
+        assertThat(indexes!!.get(0), `is`("3"))
+
+        indexes = target?.addTokenIndex(9, 6, sentenceParse, ArrayList())
+        assertThat(indexes, hasSize(2))
+        assertThat(indexes!!.get(0), `is`("3"))
+        assertThat(indexes.get(1), `is`("4"))
+    }
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        @Throws(Exception::class)
+        fun before() {
+            val modelParameters = GrobidConfig.ModelParameters()
+            modelParameters.name = "bao"
+            GrobidProperties.addModel(modelParameters)
+        }
+    }
+}

--- a/src/test/kotlin/org/grobid/core/engines/QuantitiesEngineTest.kt
+++ b/src/test/kotlin/org/grobid/core/engines/QuantitiesEngineTest.kt
@@ -10,11 +10,18 @@ class QuantitiesEngineTest {
 
     @Test
     fun normaliseAndCleanup_shouldReplaceToken() {
-        val tokens = QuantityAnalyzer.getInstance().tokenizeWithLayoutToken("This \uF0A0 is an interesting") 
+        val tokens = QuantityAnalyzer.getInstance().tokenizeWithLayoutToken("This \uF0A0 is an interesting")
         val tokensNormalised = QuantitiesEngine.normaliseAndCleanup(tokens)
-        
-        assertThat(tokensNormalised, hasSize(tokens.size))
-        assertThat(tokensNormalised[2].text, `is`(" "))
+
+        assertThat(tokensNormalised, hasSize(tokens.size - 2))
+        assertThat(tokensNormalised[1].text, `is`(" "))
+        assertThat(tokensNormalised[2].text, `is`("is"))
+        assertThat(tokensNormalised[0].offset, `is`(0))    
+        assertThat(tokensNormalised[1].offset, `is`(4))    
+        assertThat(tokensNormalised[2].offset, `is`(5))    
+        assertThat(tokensNormalised[3].offset, `is`(7))    
+        assertThat(tokensNormalised[4].offset, `is`(8))    
+        assertThat(tokensNormalised[5].offset, `is`(10))
     }
 
     @Test

--- a/src/test/kotlin/org/grobid/core/engines/QuantitiesEngineTest.kt
+++ b/src/test/kotlin/org/grobid/core/engines/QuantitiesEngineTest.kt
@@ -9,11 +9,20 @@ import org.junit.jupiter.api.Test
 class QuantitiesEngineTest {
 
     @Test
-    fun normaliseAndCleanup() {
+    fun normaliseAndCleanup_shouldReplaceToken() {
         val tokens = QuantityAnalyzer.getInstance().tokenizeWithLayoutToken("This \uF0A0 is an interesting") 
         val tokensNormalised = QuantitiesEngine.normaliseAndCleanup(tokens)
         
         assertThat(tokensNormalised, hasSize(tokens.size))
         assertThat(tokensNormalised[2].text, `is`(" "))
+    }
+
+    @Test
+    fun normaliseAndCleanup_shouldNotReplaceToken() {
+        val tokens = QuantityAnalyzer.getInstance().tokenizeWithLayoutToken("This material is an interesting")
+        val tokensNormalised = QuantitiesEngine.normaliseAndCleanup(tokens)
+
+        assertThat(tokensNormalised, hasSize(tokens.size))
+        assertThat(tokensNormalised[2].text, `is`("material"))
     }
 }

--- a/src/test/kotlin/org/grobid/core/engines/QuantitiesEngineTest.kt
+++ b/src/test/kotlin/org/grobid/core/engines/QuantitiesEngineTest.kt
@@ -1,0 +1,19 @@
+package org.grobid.core.engines;
+
+import org.grobid.core.analyzers.QuantityAnalyzer
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+
+class QuantitiesEngineTest {
+
+    @Test
+    fun normaliseAndCleanup() {
+        val tokens = QuantityAnalyzer.getInstance().tokenizeWithLayoutToken("This \uF0A0 is an interesting") 
+        val tokensNormalised = QuantitiesEngine.normaliseAndCleanup(tokens)
+        
+        assertThat(tokensNormalised, hasSize(tokens.size))
+        assertThat(tokensNormalised[2].text, `is`(" "))
+    }
+}

--- a/src/test/kotlin/org/grobid/core/engines/QuantityParserTest.kt
+++ b/src/test/kotlin/org/grobid/core/engines/QuantityParserTest.kt
@@ -78,11 +78,10 @@ class QuantityParserTest {
         @JvmStatic
         @BeforeAll
         @Throws(Exception::class)
-        fun before(): Unit {
+        fun before() {
             val modelParameters = ModelParameters()
             modelParameters.name = "bao"
             GrobidProperties.addModel(modelParameters)
-            GrobidProperties.getInstance()
         }
     }
 

--- a/src/test/kotlin/org/grobid/core/engines/QuantityParserTest.kt
+++ b/src/test/kotlin/org/grobid/core/engines/QuantityParserTest.kt
@@ -1,0 +1,90 @@
+package org.grobid.core.engines
+
+import org.grobid.core.GrobidModels
+import org.grobid.core.utilities.GrobidConfig.ModelParameters
+import org.grobid.core.utilities.GrobidProperties
+import org.grobid.core.utilities.OffsetPosition
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class QuantityParserTest {
+    private var target: QuantityParser? = null
+
+    @BeforeEach
+    fun setUp() {
+        target = QuantityParser(GrobidModels.DUMMY, null, null, null)
+    }
+
+    @AfterEach
+    fun tearDown() {
+    }
+
+
+    @Test
+    fun testGetSentence_entityInsideSentence() {
+
+        val sentences: List<OffsetPosition> = listOf(
+            OffsetPosition(0, 3),
+            OffsetPosition(4, 6),
+            OffsetPosition(7, 10)
+        )
+
+        val entityPosition = OffsetPosition(1, 2)
+
+        val foundSentence = target?.findSentenceOffset(sentences, entityPosition)
+
+        assertThat(foundSentence, `is`(sentences[0]))
+    }
+
+
+    @Test
+    fun testGetSentence_entityBetweenSentences() {
+
+        val sentences: List<OffsetPosition> = listOf(
+            OffsetPosition(0, 3),
+            OffsetPosition(4, 6),
+            OffsetPosition(7, 10)
+        )
+
+        val entityPosition = OffsetPosition(2, 5)
+
+        val foundSentence = target?.findSentenceOffset(sentences, entityPosition)
+
+        assertThat(foundSentence, `is`(OffsetPosition(0, 10)))
+    }
+
+    @Test
+    fun testGetSentence_entityIncludingASentence() {
+
+        val sentences: List<OffsetPosition> = listOf(
+            OffsetPosition(0, 3),
+            OffsetPosition(4, 6),
+            OffsetPosition(7, 10)
+        )
+
+        val entityPosition = OffsetPosition(2, 8)
+
+        val foundSentence = target?.findSentenceOffset(sentences, entityPosition)
+
+        assertThat(foundSentence, `is`(OffsetPosition(0, 10)))
+    }
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        @Throws(Exception::class)
+        fun before(): Unit {
+            val modelParameters = ModelParameters()
+            modelParameters.name = "bao"
+            GrobidProperties.addModel(modelParameters)
+            GrobidProperties.getInstance()
+        }
+    }
+
+
+}

--- a/src/test/resources/config-test.yml
+++ b/src/test/resources/config-test.yml
@@ -1,51 +1,6 @@
 grobidHome: ../grobid-home
 
 models:
-  - name: "superconductors"
-    engine: "wapiti"
-    #engine: "delft"
-    wapiti:
-      # wapiti training parameters, they will be used at training time only
-      epsilon: 0.00001
-      window: 30
-      nbMaxIterations: 2000
-    delft:
-      # deep learning parameters
-      architecture: "BidLSTM_CRF"
-      #architecture: "scibert"
-      useELMo: false
-      embeddings_name: "glove-840B"
-
-  - name: "material"
-    engine: "wapiti"
-    #engine: "delft"
-    wapiti:
-      # wapiti training parameters, they will be used at training time only
-      epsilon: 0.00001
-      window: 30
-      nbMaxIterations: 2000
-    delft:
-      # deep learning parameters
-      architecture: "BidLSTM_CRF"
-      #architecture: "scibert"
-      useELMo: false
-      embeddings_name: "glove-840B"
-
-  - name: "entityLinker-material-tc"
-    engine: "wapiti"
-    #engine: "delft"
-    wapiti:
-      # wapiti training parameters, they will be used at training time only
-      epsilon: 0.00001
-      window: 30
-      nbMaxIterations: 2000
-    delft:
-      # deep learning parameters
-      architecture: "BidLSTM_CRF"
-      #architecture: "scibert"
-      useELMo: false
-      embeddings_name: "glove-840B"
-
   - name: "quantities"
     engine: "wapiti"
     #engine: "delft"


### PR DESCRIPTION
This PR attempt to solve the issue #158. In addition, as a bonus, we filter out the non-Unicode characters, in a non-destructive way: we replace them with "space"

Update: some of the problems were generated by multiple spaces that were lost after the ML call. So when data comes from PDF the duplicated spaces are removed and the offsets updated