### PR TITLE
feat(service): implement the XML input endpoint (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,15 +30,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-+ TEI output for text processing, on `POST /service/processQuantityTextTEI`. The measures are annotated inline in the text, in the same notation as the annotated corpus and the annotation guidelines (#20)
-+ Regression test asserting that `processQuantityTextTEI` answers blank or empty input the same way as `processQuantityText`: `200` with an empty TEI document, instead of a `500` (#20)
-+ `POST /service/processQuantityXML`, extracting measurements from the text carried by an XML document (TEI, ST.36, …). The path was declared in `AnnotationController` but had never been implemented. The markup is discarded and the textual chunks are processed as text; since the resulting offsets refer to the extracted text, that text is returned in a new `text` field of the response. The field is omitted when empty, so the other endpoints' responses are unchanged (#3)
-+ The XML parser used by that endpoint rejects `DOCTYPE` declarations and external entities, so a submitted document cannot read local files (XXE) or expand nested entities; malformed input is answered with `400` rather than `500` (#3)
++ TEI output for text processing on `POST /service/processQuantityTextTEI`, annotating the measures inline in the notation of the annotated corpus (#20)
++ `POST /service/processQuantityXML`, extracting measurements from the text of an XML document (TEI, ST.36, ...); the extracted text is returned in a new `text` field, since the offsets refer to it (#3)
++ The XML endpoint rejects `DOCTYPE` declarations and external entities (XXE), and answers malformed input with `400` rather than `500` (#3)
 
 ### Fixed
 
-+ `POST /service/processQuantityTextTEI` now answers blank or empty input the same way as the JSON endpoint `processQuantityText`: `200` with an empty TEI document, instead of a `500` (#20)
-+ Corrected the `processQuantityTextTEI` example in the REST API documentation to use the uppercase unit type notation (`type="TIME"`) emitted by the code, consistent with the annotated corpus and the annotation guidelines (#20)
++ `processQuantityTextTEI` answers blank or empty input with `200` and an empty TEI document, as `processQuantityText` does, instead of `500` (#20)
++ Corrected the `processQuantityTextTEI` example in the REST API documentation to the uppercase unit type the code actually emits (#20)
 
 ### Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 + TEI output for text processing, on `POST /service/processQuantityTextTEI`. The measures are annotated inline in the text, in the same notation as the annotated corpus and the annotation guidelines (#20)
 + Regression test asserting that `processQuantityTextTEI` answers blank or empty input the same way as `processQuantityText`: `200` with an empty TEI document, instead of a `500` (#20)
++ `POST /service/processQuantityXML`, extracting measurements from the text carried by an XML document (TEI, ST.36, …). The path was declared in `AnnotationController` but had never been implemented. The markup is discarded and the textual chunks are processed as text; since the resulting offsets refer to the extracted text, that text is returned in a new `text` field of the response. The field is omitted when empty, so the other endpoints' responses are unchanged (#3)
++ The XML parser used by that endpoint rejects `DOCTYPE` declarations and external entities, so a submitted document cannot read local files (XXE) or expand nested entities; malformed input is answered with `400` rather than `500` (#3)
 
 ### Fixed
 

--- a/doc/restAPI.md
+++ b/doc/restAPI.md
@@ -210,6 +210,42 @@ The unit type is serialised with the uppercase enum name (`type="TIME"`), as in 
 guidelines, whereas the JSON output uses the lowercase label (`"type": "time"`): the two notations
 are intentionally different.
 
+## Process Quantities from XML
+
+Same extraction as `processQuantityText`, over the text carried by an XML document rather than
+over raw text.
+
+>    POST    /service/processQuantityXML
+
+The file is supplied using the `input` FormData parameter:
+
+``` shell
+    curl --form input=@./myFile.xml localhost:8060/service/processQuantityXML
+```
+
+The markup is discarded first: the textual chunks — `p` elements, or `paragraph` for ST.36
+patents — are extracted and joined with newlines, and the result is processed as text. No schema
+is assumed beyond that, so TEI, ST.36 and most other flavours work.
+
+Because the offsets in the response refer to the *extracted* text, not to the original XML, that
+text is returned alongside the measurements in a `text` field:
+
+``` json
+    {
+      "runtime": 42,
+      "text": "I've lost two minutes.\nAnd 3 kg.",
+      "measurements": [ ... ]
+    }
+```
+
+The `text` field appears only in this endpoint's response; `processQuantityText` is unchanged,
+since there the caller already has the text. Mapping a measurement back to a position in the
+original markup is not supported — use the extracted text.
+
+A document that is not well-formed XML is answered with **400**. Note that `DOCTYPE` declarations
+are rejected outright, so documents relying on a DTD for entity definitions have to be resolved
+before being submitted.
+
 ## Process Quantities from PDF
 
 Process PDF and generate annotations of measurements. The results are annotations which, by containing coordinate information, can be used to annotate directly a PDF. 

--- a/src/main/java/org/grobid/core/data/MeasurementsResponse.java
+++ b/src/main/java/org/grobid/core/data/MeasurementsResponse.java
@@ -1,13 +1,16 @@
 package org.grobid.core.data;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import org.grobid.core.layout.Page;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @JsonInclude(Include.NON_EMPTY)
 public class MeasurementsResponse {
@@ -35,6 +38,24 @@ public class MeasurementsResponse {
     }
 
     private List<Page> pages;
+
+    /**
+     * The text the measurement offsets refer to, when the caller does not already have it.
+     * Set by the XML endpoint, which extracts the text from the markup before processing it -
+     * without it the offsets in the response cannot be resolved to anything. Left null by the
+     * text endpoint, where the caller supplied the text in the first place.
+     * <p>
+     * See https://github.com/lfoppiano/grobid-quantities/issues/3
+     */
+    private String text;
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
 
     public List<Measurement> getMeasurements() {
         return measurements;
@@ -65,6 +86,10 @@ public class MeasurementsResponse {
 
         jsonBuilder.append("{ ");
         jsonBuilder.append("\"runtime\" : " + runtime);
+        if (isNotBlank(getText())) {
+            byte[] encodedText = JsonStringEncoder.getInstance().quoteAsUTF8(getText());
+            jsonBuilder.append(", \"text\" : \"" + new String(encodedText, UTF_8) + "\"");
+        }
         boolean first = true;
         if (isNotEmpty(getPages())) {
             // page height and width

--- a/src/main/java/org/grobid/core/engines/QuantitiesEngine.java
+++ b/src/main/java/org/grobid/core/engines/QuantitiesEngine.java
@@ -22,6 +22,7 @@ import org.grobid.core.engines.label.SegmentationLabels;
 import org.grobid.core.engines.label.TaggingLabels;
 import org.grobid.core.layout.LayoutToken;
 import org.grobid.core.layout.LayoutTokenization;
+import org.grobid.core.sax.TextChunkSaxHandler;
 import org.grobid.core.tokenization.LabeledTokensContainer;
 import org.grobid.core.tokenization.TaggingTokenCluster;
 import org.grobid.core.tokenization.TaggingTokenClusteror;
@@ -33,7 +34,9 @@ import org.grobid.core.utilities.UnitUtilities;
 import org.grobid.service.exceptions.GrobidServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.SAXParserFactory;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -356,6 +359,64 @@ public class QuantitiesEngine {
         } catch (Exception e) {
             throw new GrobidServiceException("An unexpected exception occurs. ", e, Response.Status.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    /**
+     * Same extraction as {@link #processText(String)}, over the text carried by an XML document
+     * rather than over raw text. The markup is discarded: the textual chunks (`p`/`paragraph`
+     * elements, as recognised by {@link TextChunkSaxHandler}, which copes with TEI and ST.36
+     * alike) are extracted and joined with newlines, and that text is processed.
+     * <p>
+     * The offsets of the response therefore refer to the extracted text, not to the XML, so the
+     * extracted text is returned along with the measurements - see
+     * {@link MeasurementsResponse#getText()}. Mapping a measurement back to a position in the
+     * original markup is not supported.
+     * <p>
+     * See https://github.com/lfoppiano/grobid-quantities/issues/3
+     */
+    public MeasurementsResponse processXml(InputStream xml) {
+        try {
+            long start = System.currentTimeMillis();
+
+            String text = extractText(xml);
+            MeasurementsResponse response = new MeasurementsResponse(quantityParser.process(text));
+            response.setText(text);
+            response.setRuntime(System.currentTimeMillis() - start);
+
+            return response;
+        } catch (GrobidServiceException e) {
+            throw e;
+        } catch (NoSuchElementException e) {
+            throw new GrobidServiceException("Could not get an engine from the pool within configured time. Sending service unavailable.", e, Response.Status.SERVICE_UNAVAILABLE);
+        } catch (Exception e) {
+            throw new GrobidServiceException("An unexpected exception occurs. ", e, Response.Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Concatenates the textual chunks of an XML document. Malformed input is reported as a 400:
+     * it is the caller's document that is wrong, not the service.
+     * <p>
+     * The parser is configured to reject DOCTYPE declarations, which disables entity expansion
+     * altogether - external entities (XXE) as well as the internal ones that make up a billion
+     * laughs attack. The input comes from the network, so this is not optional.
+     */
+    static String extractText(InputStream xml) {
+        TextChunkSaxHandler handler = new TextChunkSaxHandler();
+        try {
+            SAXParserFactory factory = SAXParserFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.newSAXParser().parse(xml, handler);
+        } catch (SAXException e) {
+            throw new GrobidServiceException("The input could not be parsed as XML. " + e.getMessage(), e, Response.Status.BAD_REQUEST);
+        } catch (Exception e) {
+            throw new GrobidServiceException("An unexpected exception occurs while reading the XML input. ", e, Response.Status.INTERNAL_SERVER_ERROR);
+        }
+
+        return String.join("\n", handler.getChunks());
     }
 
     /**

--- a/src/main/java/org/grobid/service/controller/AnnotationController.java
+++ b/src/main/java/org/grobid/service/controller/AnnotationController.java
@@ -102,6 +102,22 @@ public class AnnotationController {
         return engine.processTextTei(text);
     }
 
+    /**
+     * Extracts the measurements from the text carried by an XML document. The markup is
+     * discarded, so the offsets of the response refer to the extracted text, which is returned
+     * along with them. See https://github.com/lfoppiano/grobid-quantities/issues/3
+     */
+    @Path(PATH_QUANTITY_XML)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    @POST
+    public String processXML(@FormDataParam("input") InputStream uploadedInputStream,
+                             @FormDataParam("input") FormDataContentDisposition fileDetail) {
+        MeasurementsResponse response = engine.processXml(uploadedInputStream);
+
+        return response.toJson();
+    }
+
     @Path(PATH_PARSE_MEASURE)
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
     @POST

--- a/src/main/resources/web/grobid/grobid-quantities.js
+++ b/src/main/resources/web/grobid/grobid-quantities.js
@@ -240,7 +240,7 @@ var grobid = (function ($) {
                         message = split[split.length - 1]
                         if (message.startsWith(":")) {
                             message = message.substring(1);
-                        } 
+                        }
                     } else {
                         message = message['message']
                     }
@@ -270,6 +270,19 @@ var grobid = (function ($) {
         if (selected === 'processQuantityText') {
             var formData = new FormData();
             formData.append("text", $('#inputTextArea').val());
+
+            $.ajax({
+                type: 'POST',
+                url: urlLocal,
+                data: formData,
+                success: SubmitSuccesful,
+                error: onError,
+                contentType: false,
+                processData: false
+            });
+        } else if (selected === 'processQuantityXML') {
+            var form = document.getElementById('gbdForm');
+            var formData = new FormData(form);
 
             $.ajax({
                 type: 'POST',
@@ -456,7 +469,10 @@ var grobid = (function ($) {
 
         display += '<pre style="background-color:#FFF;width:95%;" id="displayAnnotatedText">';
 
-        var string = $('#inputTextArea').val();
+        var string = responseJson.text;
+        if (!string) {
+            string = $('#inputTextArea').val();
+        }
         var newString = "";
         var lastMaxIndex = string.length;
 
@@ -827,7 +843,7 @@ var grobid = (function ($) {
             measurementType = "List";
             string = toHtml(quantityMap, measurementType, $(this).position().top);
         }
-//console.log(string); 
+        //console.log(string); 
         $('#detailed_annot-' + pageIndex).html(string);
         $('#detailed_annot-' + pageIndex).show();
     }
@@ -1035,7 +1051,7 @@ var grobid = (function ($) {
     }
 
     function SubmitSuccessfulXML(responseText, statusText) {
-        $('#requestResult').html("<p>Not implemented yet ;)</p>");
+        SubmitSuccesfulText(responseText, statusText);
     }
 
     function processChange() {

--- a/src/main/resources/web/grobid/grobid-quantities.js
+++ b/src/main/resources/web/grobid/grobid-quantities.js
@@ -469,7 +469,10 @@ var grobid = (function ($) {
 
         display += '<pre style="background-color:#FFF;width:95%;" id="displayAnnotatedText">';
 
-
+        var string = responseJson.text;
+        if (!string) {
+            string = $('#inputTextArea').val();
+        }
         var newString = "";
         var lastMaxIndex = string.length;
 

--- a/src/main/resources/web/grobid/grobid-quantities.js
+++ b/src/main/resources/web/grobid/grobid-quantities.js
@@ -554,17 +554,17 @@ var grobid = (function ($) {
                             console.log("Sorting of quantities as present in the server's response not valid for this client.");
                             // note: this should never happen?
                         } else {
-                            newString += string.substring(pos, start)
+                            newString += htmll(string.substring(pos, start))
                                 + ' <span id="annot-' + currentMeasurementIndex + '-' + currentQuantityIndex + '" rel="popover" data-color="' + quantityType + '">'
                                 + '<span class="label ' + quantityType + '" style="cursor:hand;cursor:pointer;" >'
-                                + string.substring(start, end) + '</span></span>';
+                                + htmll(string.substring(start, end)) + '</span></span>';
                             pos = end;
                         }
                     }
                     measurementMap[currentMeasurementIndex] = quantityMap;
                 }
             }
-            newString += string.substring(pos, string.length);
+            newString += htmll(string.substring(pos, string.length));
         }
 
         newString = "<p>" + newString.replace(/(\r\n|\n|\r)/gm, "</p><p>") + "</p>";

--- a/src/main/resources/web/grobid/grobid-quantities.js
+++ b/src/main/resources/web/grobid/grobid-quantities.js
@@ -469,10 +469,7 @@ var grobid = (function ($) {
 
         display += '<pre style="background-color:#FFF;width:95%;" id="displayAnnotatedText">';
 
-        var string = responseJson.text;
-        if (!string) {
-            string = $('#inputTextArea').val();
-        }
+
         var newString = "";
         var lastMaxIndex = string.length;
 

--- a/src/test/java/org/grobid/core/data/MeasurementsResponseTest.java
+++ b/src/test/java/org/grobid/core/data/MeasurementsResponseTest.java
@@ -1,0 +1,63 @@
+package org.grobid.core.data;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * The `text` field carries the text the offsets refer to, for the callers that do not have it -
+ * the XML endpoint extracts the text from the markup itself.
+ * See https://github.com/lfoppiano/grobid-quantities/issues/3
+ */
+class MeasurementsResponseTest {
+
+    private JsonNode json(MeasurementsResponse response) throws Exception {
+        return new ObjectMapper().readTree(response.toJson());
+    }
+
+    @Test
+    void withoutText_shouldNotEmitTheField() throws Exception {
+        MeasurementsResponse response = new MeasurementsResponse(Collections.emptyList());
+        response.setRuntime(12);
+
+        JsonNode node = json(response);
+
+        assertFalse(node.has("text"), "the text endpoint's response must be unchanged");
+        assertEquals(12, node.get("runtime").asLong());
+    }
+
+    @Test
+    void aBlankText_shouldNotEmitTheFieldEither() throws Exception {
+        MeasurementsResponse response = new MeasurementsResponse(Collections.emptyList());
+        response.setText("   ");
+
+        assertFalse(json(response).has("text"));
+    }
+
+    @Test
+    void withText_shouldEmitItVerbatim() throws Exception {
+        MeasurementsResponse response = new MeasurementsResponse(Collections.emptyList());
+        response.setText("We lost 10 kg.\nThen 20 more.");
+
+        assertEquals("We lost 10 kg.\nThen 20 more.", json(response).get("text").asText());
+    }
+
+    /**
+     * The JSON is built by hand, so anything the extracted text may contain - quotes, newlines,
+     * backslashes, non-ASCII - has to survive the round trip.
+     */
+    @Test
+    void aTextNeedingEscaping_shouldStayValidJson() throws Exception {
+        String awkward = "a \"quoted\" value,\na back\\slash, a tab\there, and 10 µm ± 2 µm";
+
+        MeasurementsResponse response = new MeasurementsResponse(Collections.emptyList());
+        response.setText(awkward);
+
+        assertEquals(awkward, json(response).get("text").asText());
+    }
+}

--- a/src/test/java/org/grobid/core/engines/QuantitiesEngineXmlInputTest.java
+++ b/src/test/java/org/grobid/core/engines/QuantitiesEngineXmlInputTest.java
@@ -1,0 +1,122 @@
+package org.grobid.core.engines;
+
+import jakarta.ws.rs.core.Response;
+import org.apache.commons.io.IOUtils;
+import org.grobid.service.exceptions.GrobidServiceException;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The text extraction behind {@code POST /service/processQuantityXML}.
+ * See https://github.com/lfoppiano/grobid-quantities/issues/3
+ */
+class QuantitiesEngineXmlInputTest {
+
+    private String extract(String xml) {
+        try (InputStream is = IOUtils.toInputStream(xml, UTF_8)) {
+            return QuantitiesEngine.extractText(is);
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    void paragraphs_shouldBeExtractedAndJoined() {
+        String text = extract("<tei><text>"
+            + "<p>We lost 10 kg.</p>"
+            + "<p>Then 20 more.</p>"
+            + "</text></tei>");
+
+        assertEquals("We lost 10 kg.\nThen 20 more.", text);
+    }
+
+    @Test
+    void markupInsideAParagraph_shouldBeDiscardedButItsTextKept() {
+        String text = extract("<tei><text><p>We lost <hi rend=\"bold\">10</hi> kg.</p></text></tei>");
+
+        assertEquals("We lost 10 kg.", text);
+    }
+
+    /**
+     * The handler is meant to cope with the usual formats, ST.36 patents included, where the
+     * paragraph element is spelled out.
+     */
+    @Test
+    void st36Paragraphs_shouldBeExtractedToo() {
+        String text = extract("<patent-document><description>"
+            + "<paragraph>A pressure of 10 bar.</paragraph>"
+            + "</description></patent-document>");
+
+        assertEquals("A pressure of 10 bar.", text);
+    }
+
+    @Test
+    void aDocumentWithoutParagraphs_shouldYieldNoText() {
+        assertEquals("", extract("<tei><text><div>loose text</div></text></tei>"));
+    }
+
+    @Test
+    void malformedXml_shouldBeReportedAsABadRequest() {
+        GrobidServiceException e = assertThrows(GrobidServiceException.class,
+            () -> extract("<tei><text><p>unclosed"));
+
+        assertEquals(Response.Status.BAD_REQUEST, e.getResponseCode());
+    }
+
+    /**
+     * The input comes from the network. A DOCTYPE declaration must not be honoured, otherwise the
+     * document can read local files (XXE) or blow up the parser through nested entities.
+     */
+    @Test
+    void anExternalEntity_shouldNotBeResolved() throws Exception {
+        File secret = File.createTempFile("quantities-xxe-", ".txt");
+        secret.deleteOnExit();
+        Files.write(Path.of(secret.getAbsolutePath()), "TOP-SECRET".getBytes(UTF_8));
+
+        String xml = "<?xml version=\"1.0\"?>"
+            + "<!DOCTYPE tei [<!ENTITY xxe SYSTEM \"file://" + secret.getAbsolutePath() + "\">]>"
+            + "<tei><text><p>&xxe;</p></text></tei>";
+
+        GrobidServiceException e = assertThrows(GrobidServiceException.class, () -> extract(xml));
+
+        assertEquals(Response.Status.BAD_REQUEST, e.getResponseCode());
+        assertFalse(String.valueOf(e.getMessage()).contains("TOP-SECRET"));
+    }
+
+    @Test
+    void aBillionLaughs_shouldNotBeExpanded() {
+        StringBuilder xml = new StringBuilder("<?xml version=\"1.0\"?><!DOCTYPE lolz [");
+        xml.append("<!ENTITY lol \"lol\">");
+        for (int i = 1; i <= 9; i++) {
+            xml.append("<!ENTITY lol").append(i).append(" \"");
+            for (int j = 0; j < 10; j++) {
+                xml.append("&lol").append(i == 1 ? "" : String.valueOf(i - 1)).append(";");
+            }
+            xml.append("\">");
+        }
+        xml.append("]><tei><text><p>&lol9;</p></text></tei>");
+
+        GrobidServiceException e = assertThrows(GrobidServiceException.class, () -> extract(xml.toString()));
+
+        assertEquals(Response.Status.BAD_REQUEST, e.getResponseCode());
+    }
+
+    @Test
+    void aDoctypeAlone_shouldAlreadyBeRejected() {
+        GrobidServiceException e = assertThrows(GrobidServiceException.class,
+            () -> extract("<!DOCTYPE tei SYSTEM \"tei.dtd\"><tei><text><p>10 kg</p></text></tei>"));
+
+        assertEquals(Response.Status.BAD_REQUEST, e.getResponseCode());
+        assertTrue(String.valueOf(e.getMessage()).toLowerCase().contains("doctype"));
+    }
+}


### PR DESCRIPTION
AnnotationController declared PATH_QUANTITY_XML since the first version of the web services, but no method was ever bound to it. Implement it on top of TextChunkSaxHandler, the same extraction the training data generation uses: the markup is discarded, the p/paragraph chunks are joined with newlines, and the text is processed as processQuantityText would.

The offsets of the response then refer to the extracted text, which the caller does not have - unlike the text endpoint, where they supplied it. Return it in a new 'text' field, omitted when empty so the responses of the other endpoints are byte-identical.

The parser reads documents coming from the network, so it rejects DOCTYPE declarations outright: that disables external entities (XXE) and nested entity expansion in one go. Malformed input is a 400, not a 500 - it is the submitted document that is wrong.