### PR TITLE
Guidelines and documentation updates 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 + The bounds on the request queue are no longer implicit (#159). Requests over `maxParallelRequests` are queued, and the queue used to be bounded by whatever the underlying Jetty version happened to default to. With Jetty 9's `QoSFilter` that was the servlet default async timeout of 30 seconds, which is why raising the connector's `idleTimeout` to 120 seconds did not stop requests from failing with `503` after ~30 seconds. Jetty 12's `QoSHandler` defaults differently again (1024-long queue, no waiting limit); all three bounds are now set explicitly from the configuration instead of inherited. Note that neither these settings nor `idleTimeout` bound how long a request may take to be answered once it holds a slot
 + `config-docker.yml` no longer carries a `views` key, which the configuration class does not declare. Since the application enables `FAIL_ON_UNKNOWN_PROPERTIES`, this aborted startup inside the Docker image with `Unrecognized field at: views`. Both shipped configuration files are now covered by a test that parses them the way the application does
 
+### Fixed
+
++ `ValueParserTest.testTagValue_exponential_1/2` no longer fail under Grobid 0.9.1. Grobid 0.9.1 makes the `FeatureFactory` constructor eagerly build the real `Lexicon`, which loads `english.wf` from grobid-home, so the tests' PowerMock `@SuppressStaticInitializationFor("...Lexicon")` mock and `Whitebox`-injected `Lexicon` no longer intercepted it and the tests failed against a null grobid-home. `getWapitiResult` only needs each token and its label, so the feature rows are now built directly (as `UnitParserTest` already did) instead of via `FeaturesVectorValues`/`FeatureFactory`, and PowerMock is dropped from this test (fef085d)
+
 ### Known issues
 
-+ `ValueParserTest.testTagValue_exponential_1/2` fail after the Grobid 0.9.1 upgrade: Grobid 0.9.1 changed where the English word-forms lexicon (`english.wf`) is loaded, so the tests' PowerMock `@SuppressStaticInitializationFor("...Lexicon")` mock no longer intercepts it and it loads against a null grobid-home. These should be migrated off PowerMock (already a standing TODO in `build.gradle`) or reworked to run against a real grobid-home. The other 152 unit tests pass.
++ None currently.
 
 ## [0.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-+ `ValueParserTest.testTagValue_exponential_1/2` no longer fail under Grobid 0.9.1. Grobid 0.9.1 makes the `FeatureFactory` constructor eagerly build the real `Lexicon`, which loads `english.wf` from grobid-home, so the tests' PowerMock `@SuppressStaticInitializationFor("...Lexicon")` mock and `Whitebox`-injected `Lexicon` no longer intercepted it and the tests failed against a null grobid-home. `getWapitiResult` only needs each token and its label, so the feature rows are now built directly (as `UnitParserTest` already did) instead of via `FeaturesVectorValues`/`FeatureFactory`, and PowerMock is dropped from this test (fef085d)
++ `ValueParserTest.testTagValue_exponential_1/2` no longer fail under Grobid 0.9.1: the feature rows are built directly instead of through `FeatureFactory`, which now eagerly loads the real `Lexicon` (fef085d)
 
 ### Known issues
 
@@ -38,9 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.9.0]
 
-> :information_source: 0.9.0 was never released - no `v0.9.0` tag was ever cut, `v0.8.2` being the
-> last release. The entries below are kept grouped because they are the work of following Grobid
-> 0.9.0, but they ship together with the `[Unreleased]` section above as part of **0.9.1**.
+> :information_source: 0.9.0 was never released - no `v0.9.0` tag was ever cut. These entries ship with the `[Unreleased]` section above, as part of 0.9.1.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.9.0]
 
-> :information_source: 0.9.0 was never released - no `v0.9.0` tag was ever cut. These entries ship with the `[Unreleased]` section above, as part of 0.9.1.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.9.0]
 
+> :information_source: 0.9.0 was never released - no `v0.9.0` tag was ever cut, `v0.8.2` being the
+> last release. The entries below are kept grouped because they are the work of following Grobid
+> 0.9.0, but they ship together with the `[Unreleased]` section above as part of **0.9.1**.
+
 ### Changed
 
 + Updated to Grobid version 0.9.0

--- a/doc/evaluation-scores.md
+++ b/doc/evaluation-scores.md
@@ -42,7 +42,7 @@ The models are organised as follows:
 
 The evaluation was performed on the holdout dataset from the grobid-quantities dataset.
 Average values are computed as Micro average.
-To reproduce it, see `evaluation_doc`{.interpreted-text role="ref"}.
+To reproduce it, see [Evaluation](training.md#evaluation).
 
 #### Quantities
 
@@ -121,5 +121,5 @@ Units were evaluated using UNISCOR dataset. For more information check the secti
 
 ### Other published results
 
-> :information_source: The paper \"Automatic Identification and Normalisation of Physical Measurements in Scientific
-> Literature,\" published in September 2019, reported macro averaged evaluation scores.
+> :information_source: The paper "Automatic Identification and Normalisation of Physical Measurements in Scientific
+> Literature," published in September 2019, reported macro averaged evaluation scores.

--- a/doc/gettingStarted.md
+++ b/doc/gettingStarted.md
@@ -2,9 +2,22 @@
 
 > :information_source: Platform support follows Grobid - Linux and macOS, on x86-64 and ARM alike, and Windows through Docker only - see the [Grobid installation guide](https://grobid.readthedocs.io/en/latest/Install-Grobid/).
 
-> :warning: Since grobid-quantities 0.7.3 (using grobid 0.7.3), we've extended the support to JDK after version 11. This requires specifying the [java.library.path]{.title-ref} explicitly. *All these issues are solved by using Docker containers*.
+> :information_source: Running the JAR directly requires `-Djava.library.path` to be set, so that the
+> JVM finds Grobid's native libraries (and JEP, if you use the deep learning models). The exact
+> value depends on your platform and Python environment - see
+> [Start and use the service](#start-and-use-the-service). Running through `./gradlew run`, or
+> through the Docker image, sets it for you.
 
 ## Upgrade
+
+**Versioning follows Grobid.** A grobid-quantities release carries the version of the Grobid
+release it is built against, so upgrading grobid-quantities generally means taking on Grobid's
+own upgrade notes for that version - each section below links to them where relevant.
+
+Releases are infrequent, and are likely to become more so: the project is maintained on limited
+time. If you need something that is already on `master` but not yet released, build from source
+(see [Install and build](#install-and-build)) or use the `lfoppiano/grobid-quantities:latest-develop`
+Docker image, which CI builds and pushes on every commit.
 
 ### 0.8.2 to 0.9.1
 
@@ -59,9 +72,9 @@ against DeLFT >= 0.4.1 / TensorFlow 2.17.
 Only relevant if you run the DL models locally rather than through Docker. The stack moved to
 Python 3.10–3.11, TensorFlow 2.17, DeLFT >= 0.4.1 and JEP 4.3.1, which needs a **fresh Python
 environment** — see Grobid's [Deep Learning models](https://grobid.readthedocs.io/en/latest/Deep-Learning-models/)
-page. Note that the `java.library.path` used to start the service points into that environment,
-so the `python3.9` in the command lines further down this page becomes `python3.11` (or whichever
-version your environment uses).
+page. Note that the `java.library.path` used to start the service points into that environment, so
+it has to be updated to the new Python version - the examples in
+[Start and use the service](#start-and-use-the-service) use `python3.11`.
 
 #### Configuration file
 
@@ -164,6 +177,10 @@ server:
 In version 0.7.3, we have updated the DeLFT models. The DL models must be updated by running `./gradlew copyModels`.
 
 #### JDK Update
+
+> :information_source: The values below are the ones that were current at 0.7.3. For a current
+> installation see [Start and use the service](#start-and-use-the-service); grobid-quantities
+> requires JDK 21 since 0.9.0, and the Python version in these paths depends on your environment.
 
 The version 0.7.3 enables the support for running with JDK > 11. 
 We recommend running it with JDK 17. Running grobid-quantities with gradle (`./gradlew clean run`) is already supported in the `build.gradle`. 
@@ -271,10 +288,10 @@ cd PATH-TO-GROBID/grobid-quantities
 Grobid-quantities can be run with the following command: :
 
 ```shell
-    java -Djava.library.path=../grobid-home/lib/{arch}/:{virtual_env_path}/lib:{virtual_env_path}/lib/python3.9/site-packages/jep -jar build/libs/grobid-quantities-{version}-onejar.jar server resources/config/config.yml
+    java -Djava.library.path=../grobid-home/lib/{arch}/:{virtual_env_path}/lib:{virtual_env_path}/lib/python3.11/site-packages/jep -jar build/libs/grobid-quantities-{version}-onejar.jar server resources/config/config.yml
 ```
 
-> :warning: The command requires the following parameters: `{arch}` is the subdirectory under `grobid-home/lib` that support the following architectures: `lin-64`, `mac-64`, `mac_arm-64`. `{virtual_env_path}` is the path to the virtualenv (e.g. in my case is something like `/Users/lfoppiano/anaconda3/envs/jep/`)
+> :warning: The command requires the following parameters: `{arch}` is the subdirectory under `grobid-home/lib` for your platform - `lin-64`, `lin_arm-64`, `mac-64` or `mac_arm-64`. `{virtual_env_path}` is the path to the virtualenv (e.g. in my case is something like `/Users/lfoppiano/anaconda3/envs/jep/`), and `python3.11` should match the Python version of that environment. The `{virtual_env_path}` segments are only needed when running the deep learning models; the CRF models need the `grobid-home/lib` entry alone.
 
 
 ## Accessing the service

--- a/doc/gettingStarted.md
+++ b/doc/gettingStarted.md
@@ -1,8 +1,6 @@
 # Getting started
 
-> :warning: Grobid, and therefore grobid-quantities, [is not supported running natively on Windows](https://grobid.readthedocs.io/en/latest/Frequently-asked-questions/#windows-related-issues). Windows users should use the Docker image and call the service over the REST API. Note that Grobid also reports issues with the Windows Subsystem for Linux, so WSL is not a reliable alternative.
-
-> :information_source: Apple Silicon (M1 and later) is supported: Grobid ships the native Wapiti library for `mac_arm-64` and `lin_arm-64`, so the CRF models run natively on ARM. Earlier versions of this page described ARM support as "under development" - that is no longer the case. Running the *deep learning* models on ARM depends on your TensorFlow install rather than on Grobid; see [Deep Learning models](https://grobid.readthedocs.io/en/latest/Deep-Learning-models/).
+> :information_source: Platform support follows Grobid - Linux and macOS, on x86-64 and ARM alike, and Windows through Docker only - see the [Grobid installation guide](https://grobid.readthedocs.io/en/latest/Install-Grobid/).
 
 > :warning: Since grobid-quantities 0.7.3 (using grobid 0.7.3), we've extended the support to JDK after version 11. This requires specifying the [java.library.path]{.title-ref} explicitly. *All these issues are solved by using Docker containers*.
 

--- a/doc/gettingStarted.md
+++ b/doc/gettingStarted.md
@@ -1,10 +1,109 @@
 # Getting started
 
-> :warning: Grobid and grobid-quantities are [not compatible with Windows](https://grobid.readthedocs.io/en/latest/Troubleshooting/#windows-related-issues) and limited on Apple M1. While Windows users can easily use Grobid and grobid-quantities through docker containers, the support for grobid on ARM is under development, see the [latest discussion](https://github.com/kermitt2/grobid/issues/1014).
+> :warning: Grobid, and therefore grobid-quantities, [is not supported running natively on Windows](https://grobid.readthedocs.io/en/latest/Frequently-asked-questions/#windows-related-issues). Windows users should use the Docker image and call the service over the REST API. Note that Grobid also reports issues with the Windows Subsystem for Linux, so WSL is not a reliable alternative.
+
+> :information_source: Apple Silicon (M1 and later) is supported: Grobid ships the native Wapiti library for `mac_arm-64` and `lin_arm-64`, so the CRF models run natively on ARM. Earlier versions of this page described ARM support as "under development" - that is no longer the case. Running the *deep learning* models on ARM depends on your TensorFlow install rather than on Grobid; see [Deep Learning models](https://grobid.readthedocs.io/en/latest/Deep-Learning-models/).
 
 > :warning: Since grobid-quantities 0.7.3 (using grobid 0.7.3), we've extended the support to JDK after version 11. This requires specifying the [java.library.path]{.title-ref} explicitly. *All these issues are solved by using Docker containers*.
 
 ## Upgrade
+
+### 0.8.2 to 0.9.1
+
+This is the largest upgrade since 0.7.x. grobid-quantities follows Grobid, so most of the work is
+Grobid's [0.9.0](https://grobid.readthedocs.io/en/latest/Upgrading/#upgrading-to-090) and
+[0.9.1](https://grobid.readthedocs.io/en/latest/Upgrading/#upgrading-to-091) upgrades; the notes
+below are what that means for grobid-quantities specifically. **An existing 0.8.2 installation
+will not work as-is** — the build environment, the deep learning runtime and the models all
+change.
+
+#### At a glance
+
+| | 0.8.2 | 0.9.1 |
+|---|---|---|
+| Grobid | 0.8.2 | 0.9.1 |
+| JDK | 17 | **21** |
+| Gradle | 7.2 | **9.0** (wrapper bundled) |
+| Web framework | Dropwizard 4 / Jetty 11 | **Dropwizard 5 / Jetty 12** (Jakarta EE 10) |
+| Python (DL only) | 3.7–3.8 | **3.10–3.11** |
+| TensorFlow (DL only) | 2.9.x | **2.17** |
+| DeLFT (DL only) | 0.3.4 | **>= 0.4.1** |
+| JEP (DL only) | 4.0.1 | **4.3.1** |
+
+#### JDK 21 and Gradle 9
+
+Grobid 0.9.0 requires **OpenJDK 21**; 17 is no longer enough. The Gradle wrapper is committed, so
+`./gradlew` picks up Gradle 9 by itself — just make sure it runs on a JDK 21.
+
+#### Models must be updated
+
+The quantities, units and values models have to be reinstalled — the ones from 0.8.2 will not
+give correct results, and the deep learning ones will not load at all under DeLFT 0.4.x /
+TensorFlow 2.17:
+
+```shell
+cd PATH-TO-GROBID/grobid-quantities
+./gradlew installModels
+```
+
+`installModels` copies the CRF models shipped in the repository and clones the deep learning ones
+from [`sciencialab/grobid-quantities-models`](https://huggingface.co/sciencialab/grobid-quantities-models)
+on the HuggingFace Hub. That repository stores the large files with Xet, so
+[git-xet](https://hf.co/docs/hub/git-xet) has to be installed first, otherwise the clone leaves
+pointer stubs instead of model weights.
+
+Grobid's own models under `grobid-home/models/` were retrained in 0.9.0 as well, so pull them
+along with the Grobid code. If you maintain **custom-trained** models, they must be retrained
+against DeLFT >= 0.4.1 / TensorFlow 2.17.
+
+#### Deep learning environment
+
+Only relevant if you run the DL models locally rather than through Docker. The stack moved to
+Python 3.10–3.11, TensorFlow 2.17, DeLFT >= 0.4.1 and JEP 4.3.1, which needs a **fresh Python
+environment** — see Grobid's [Deep Learning models](https://grobid.readthedocs.io/en/latest/Deep-Learning-models/)
+page. Note that the `java.library.path` used to start the service points into that environment,
+so the `python3.9` in the command lines further down this page becomes `python3.11` (or whichever
+version your environment uses).
+
+#### Configuration file
+
+Dropwizard 5 validates the `server:` block more strictly than Dropwizard 4 and **aborts at
+startup** on options it does not recognise. If you kept the shipped `config.yml` there is nothing
+to do; if you maintain a customised one:
+
+- Remove `server.maxQueuedRequests`. This is the line the [0.7.3 to 0.8.0](#073-to-080) step below
+  told you to add - it is no longer accepted:
+
+    ```diff
+     server:
+       type: custom
+       ...
+       maxThreads: 2048
+    -  maxQueuedRequests: 2048
+    ```
+
+- Remove any `views:` block. It was never wired to anything here, and since the application
+  enables `FAIL_ON_UNKNOWN_PROPERTIES` it now stops the service with
+  `Unrecognized field at: views`:
+
+    ```diff
+    -views:
+    -  .mustache:
+    -    cache: false
+    ```
+
+- Keep `idleTimeout` and `acceptQueueSize` on the connector, not at the `server:` level.
+
+You can check a configuration file without starting the service:
+
+```shell
+java -jar build/libs/grobid-quantities-{version}-onejar.jar check resources/config/config.yml
+```
+
+#### Docker
+
+The image now builds on `lfoppiano/grobid:0.9.1-full`. If you derive your own image from it,
+the JEP path in `GROBID_QUANTITIES_OPTS` moved from `python3.8` to `python3.11`.
 
 ### 0.8.0 to 0.8.2
 

--- a/doc/gettingStarted.md
+++ b/doc/gettingStarted.md
@@ -94,6 +94,32 @@ In version 0.7.0, the models have been updated, therefore it is required
 to run a `./gradlew copyModels` to have properly results, especially for
 what concerns the unit normalization.
 
+## Requirements
+
+Grobid-quantities loads the models it needs on the first request and keeps them in memory, so
+the memory footprint is roughly constant once the service is warm and does not grow with the
+number of requests.
+
+| Usage                                                | Heap (`-Xmx`) | Notes                                                            |
+|------------------------------------------------------|---------------|------------------------------------------------------------------|
+| Text only (`processQuantityText`, `processUnitsText`) | 2 GB          | ~1.5 GB is used once the CRF models are loaded                    |
+| PDF (`annotateQuantityPDF`)                           | 4 GB          | the Grobid full-text models and the PDF parsing add to the above  |
+| Deep learning models (DeLFT/BERT instead of CRF)      | 8 GB          | plus a GPU if you want a reasonable throughput                    |
+
+These are the figures for a single request at a time. Concurrency is bounded by
+`maxParallelRequests` in `config.yml`; count roughly one additional core per parallel request.
+
+The text-only figure was measured on the CRF models (see
+[#108](https://github.com/lfoppiano/grobid-quantities/issues/108)); the other two are indicative
+and depend on the documents and on the models you enable.
+
+A machine with less memory than the above will typically fail with
+`java.lang.OutOfMemoryError: Java heap space` **while answering the first request**, not at
+startup, because the models are loaded lazily.
+
+Grobid-quantities also requires *JDK 21* (since version 0.9.0) and a Grobid installation - see
+below.
+
 ## Install and build
 
 #### Docker containers
@@ -111,7 +137,7 @@ The container will respond on port <http://localhost:8060>, and 8061 for the adm
 
 #### Local installation
 
-Grobid-quantities require *JDK 1.8 or greater*, and Grobid to be installed. Since version 0.7.3 we recommend to use *JDK 17 or greater*.
+Grobid-quantities requires *JDK 21* (since version 0.9.0, which follows Grobid 0.9.0) and Grobid to be installed.
 
 First install the latest version of GROBID as explained by the [documentation](http://grobid.readthedocs.org).
 

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -449,6 +449,21 @@ The counted object belongs to the quantified object, not to the unit.
 
 See issue [#46](https://github.com/lfoppiano/grobid-quantities/issues/46)
 
+#### Resolutions expressed per pixel
+
+`40 mas per pixel` and `100 km per pixel` are resolutions. The pixel is a counted object, not a
+unit, so `mas/pixel` and `km/pixel` are not annotated as units and no RESOLUTION type is needed:
+only the unit that is actually there is annotated, with its own type.
+
+``` xml
+The high spatial resolution of the images (<measure type="value"><num>40</num> <measure type="ANGLE" unit="mas">mas</measure></measure> per pixel,
+corresponding to ≥ <measure type="interval"><num atLeast="100">100</num> <measure type="LENGTH" unit="km">km</measure></measure> per pixel)
+```
+
+The `per pixel` part belongs to the quantified object.
+
+See issue [#43](https://github.com/lfoppiano/grobid-quantities/issues/43)
+
 ### Out of scope
 
 Only **expressions of quantities** are annotated, which can use numbers

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -435,6 +435,20 @@ Composed units follow the notation of the units model, e.g. `unit="km.s^-1"`, `u
 
 See issue [#39](https://github.com/lfoppiano/grobid-quantities/issues/39)
 
+#### Rates of counted objects
+
+`600 h −1` in a zenithal hourly rate means 600 meteors per hour. The unit is the reciprocal
+time, and the counted object - meteors - is not part of it: no `meteor/h` unit is created, and
+the type of the measure is the type of the unit that is actually there.
+
+``` xml
+an Earth-equivalent zenith hourly rate <measure type="value"><num>600</num> <measure type="FREQUENCY" unit="h^-1">h −1</measure></measure>
+```
+
+The counted object belongs to the quantified object, not to the unit.
+
+See issue [#46](https://github.com/lfoppiano/grobid-quantities/issues/46)
+
 ### Out of scope
 
 Only **expressions of quantities** are annotated, which can use numbers

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -419,6 +419,22 @@ they are realistic noise. For example:
 2.5 • -> <measure type="value"><num>2.5</num><measure type="ANGLE" unit="°">°</measure></measure>
 ```
 
+#### Value of the `@unit` attribute
+
+The `@unit` attribute records the unit as it is *known to the lexicon*, not as it is written in
+the text. Use the first notation of the lexicon entry
+(`src/main/resources/lexicon/en/units.json`) when the unit has one, e.g. `min` and not `minute`,
+`km` and not `kilometre`. When a unit has no notation, use the singular lemma, e.g.
+`unit="week"`.
+
+This settles the ambiguity of units with several accepted symbols (`a` and `yr` for the year):
+the lexicon entry decides, and annotators do not have to. When the unit is missing from the
+lexicon, add it there rather than inventing a notation in the annotation.
+
+Composed units follow the notation of the units model, e.g. `unit="km.s^-1"`, `unit="h^-1"`.
+
+See issue [#39](https://github.com/lfoppiano/grobid-quantities/issues/39)
+
 ### Out of scope
 
 Only **expressions of quantities** are annotated, which can use numbers

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -491,6 +491,24 @@ unit type for them yet, so they use `UNKNOWN` for the time being, as allowed by 
 
 See issue [#62](https://github.com/lfoppiano/grobid-quantities/issues/62)
 
+#### Durations counted from an implicit origin
+
+`since about two decades`, `over the past three decades` and the like express a duration counted
+from an origin that the sentence does not give. The origin is not annotated and not reconstructed
+- it would mean guessing the publication date.
+
+The duration itself is a **value**, and becomes an **interval** only when the text carries a
+bounding marker (`over`, `more than`, `at least`, `up to`, `less than`), which also decides
+between `atLeast` and `atMost`:
+
+``` xml
+the mechanical oscillator method is well established since about <measure type="value"><num>2</num> <measure type="TIME" unit="decade">decades</measure></measure>
+
+Over the past <measure type="interval"><num atLeast="3">three</num> <measure type="TIME" unit="decade">decades</measure></measure>
+```
+
+See issue [#63](https://github.com/lfoppiano/grobid-quantities/issues/63)
+
 ### Out of scope
 
 Only **expressions of quantities** are annotated, which can use numbers

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -756,7 +756,7 @@ This labels are combined to recognise this type of values:
   <value><time>2001 August</time></value\>
   ```
 
-## Quantified objects CRF model {#Quantified objects CRF model}
+## Quantified objects CRF model {#quantified-object-model}
 
 **Currently work in progress** The quantified object (or substance) is the object for which the measurement is expressed. For example *A mixture of 10kg of silicon nitride powder*. The object is the `silicon nitride powder` which is attached to the measurement of `10`
 with unit `Kg`.

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -798,6 +798,18 @@ when the comet was at <measure type="value" ptr="#1"><num>3.82</num> <measure ty
 
 See issue [#81](https://github.com/lfoppiano/grobid-quantities/issues/81)
 
+### An event is not the quantified object of its date
+
+In `Comet C/2013 A1 will have a close encounter with Mars on October 19, 2014` the date is
+annotated as a measure but carries no quantified object: a quantified object is an entity *being
+measured*, and `close encounter` is not measured by the date on which it happens.
+
+``` xml
+Comet C/2013 A1 (Siding Spring) will have a close encounter with Mars on <measure type="value"><date when="2014-10-19">October 19, 2014</date></measure>.
+```
+
+See issue [#79](https://github.com/lfoppiano/grobid-quantities/issues/79)
+
 ### How to annotate?
 
 Annotating the quantifiedObject is a complicated task, because it

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -464,6 +464,21 @@ The `per pixel` part belongs to the quantified object.
 
 See issue [#43](https://github.com/lfoppiano/grobid-quantities/issues/43)
 
+#### Currencies
+
+Amounts of money (`150$`, `3 €`) are quantities and are annotated as such. There is no unit type
+for currencies yet, so they use `UNKNOWN` for the time being, as allowed by the
+[unit type vocabulary](#unit-type-vocabulary) section:
+
+``` xml
+<measure type="value"><num>150</num> <measure type="UNKNOWN" unit="$">$</measure></measure>
+```
+
+Annotating them now means the model learns to spot them; giving them a proper type is a
+vocabulary and lexicon change.
+
+See issue [#59](https://github.com/lfoppiano/grobid-quantities/issues/59)
+
 ### Out of scope
 
 Only **expressions of quantities** are annotated, which can use numbers

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -479,6 +479,18 @@ vocabulary and lexicon change.
 
 See issue [#59](https://github.com/lfoppiano/grobid-quantities/issues/59)
 
+#### Amounts of data
+
+Amounts of data (`2.0 Gb RAM`, `500 MB`) are quantities and are annotated as such. There is no
+unit type for them yet, so they use `UNKNOWN` for the time being, as allowed by the
+[unit type vocabulary](#unit-type-vocabulary) section:
+
+``` xml
+<measure type="value"><num>2.0</num> <measure type="UNKNOWN" unit="Gb">Gb</measure></measure> RAM
+```
+
+See issue [#62](https://github.com/lfoppiano/grobid-quantities/issues/62)
+
 ### Out of scope
 
 Only **expressions of quantities** are annotated, which can use numbers

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -786,6 +786,18 @@ via the attribute [ptr=\"#ID\"]{.title-ref}.
 > :information_source: This implementation allows the linking of objects directly attached on the left or right of the measurement, for the time being far entities
 are not supported.
 
+### A reference point is not a quantified object
+
+In `the comet was at 3.82 AU from the Sun` the measure is annotated normally, and `from the Sun`
+is the reference of the distance: it is part of the quantified object (`distance ... from the
+Sun`), never a separate measure.
+
+``` xml
+when the comet was at <measure type="value" ptr="#1"><num>3.82</num> <measure type="LENGTH" unit="AU">AU</measure></measure> from the Sun
+```
+
+See issue [#81](https://github.com/lfoppiano/grobid-quantities/issues/81)
+
 ### How to annotate?
 
 Annotating the quantifiedObject is a complicated task, because it

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -509,6 +509,17 @@ Over the past <measure type="interval"><num atLeast="3">three</num> <measure typ
 
 See issue [#63](https://github.com/lfoppiano/grobid-quantities/issues/63)
 
+#### Possessive and deictic time expressions
+
+Expressions like `this year's minimum extent is lower than last year's` refer to a period without
+expressing a quantity of it: they have neither a value nor a unit to attach one to, and resolving
+them requires the document date. They are not annotated.
+
+The same holds for vague time expressions such as `late July` or `end of the month`, tracked
+separately in issue [#27](https://github.com/lfoppiano/grobid-quantities/issues/27).
+
+See issue [#28](https://github.com/lfoppiano/grobid-quantities/issues/28)
+
 ### Out of scope
 
 Only **expressions of quantities** are annotated, which can use numbers

--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -2,7 +2,7 @@
 
 The first step of the annotation process is to generate training data from unlabeled documents based on the current
 models.
-The procedure is explained in details in `training_data`{.interpreted-text role="ref"}.
+The procedure is explained in details in [Train and evaluation](training.md#generation-of-training-data).
 GROBID will create the training data corresponding to these documents in the right TEI format and with pre-annotations.
 The annotation work then consists of manually checking the produced annotations and adding the missing ones.
 
@@ -25,7 +25,7 @@ In this document, after the general rules, we describe the annotation guidelines
 - [Quantified objects model substance model](#quantified-object-model) - **Work in progress**
 
 > :warning: References markers in the text such as `[...] previous work, 10 showed that we are right [...]`, 10 refers to the references number 10 and should be ignored. The reference marker
-should be commented out: `[...] previous work, <!--10--> showed that we are right [...]`. This is valid for any numerical reference number: \[1\], 1 and with other styles: (Foppiano et al, 2021), Foppiano et al. (2021), etc.
+should be commented out: `[...] previous work, <!--10--> showed that we are right [...]`. This is valid for any numerical reference number: [1], 1 and with other styles: (Foppiano et al, 2021), Foppiano et al. (2021), etc.
 
 > :warning: If the year is not present, and the reference just refers to some author, they should be left in the file. For example `Drodzov et al demonstrate that we are right[...]`.
 
@@ -225,8 +225,8 @@ for flexural samples the size is <measure type="list"><num>100</num> <measure ty
 ```
 
 If there are no intermediary values, it's an argument for deciding to
-annotate an element as a list, for example this ranked list (issue [#65
-\<https://github.com/kermitt2/grobid-quantities/issues/65\>]{.title-ref}):
+annotate an element as a list, for example this ranked list (issue
+[#65](https://github.com/kermitt2/grobid-quantities/issues/65)):
 
 ``` xml
 for every lower position in the general classification the prize money was more or less halved between
@@ -242,7 +242,7 @@ for every lower position in the general classification the prize money was more 
 #### Dates
 
 Dates are time measurements, they are thus also encoded in the training
-data as a complement to the other \_[TIME]() expressions involving time
+data as a complement to the other `TIME` expressions involving time
 units. In TEI P5, the dates are marked with a specific element `<date>`
 which can be contained in an element `<measure>`. The encoding is then
 straightforward for atomic values (with attribute `@when`), intervals
@@ -284,7 +284,7 @@ With UTC inside the annotation which is important to know exactly the
 "time" measure.
 
 - for a time expression not linked to a date, like the expression of
-  an \"hour\", it's appropriate to annotate with the tag `<time>`, to
+  an "hour", it's appropriate to annotate with the tag `<time>`, to
   distinguish from the `<date>` case (see issue
   [#48](https://github.com/kermitt2/grobid-quantities/issues/48)):
 
@@ -360,16 +360,20 @@ imprecisely :
 the reference solution becomes distinct from the ballistic solution only a <measure type="value"><num>couple</num> of <measure type="TIME" unit="week">weeks</measure></measure> before the encounter. 
 ```
 
-Determiners are left outside ([a \<measure
-type=\"value\"\>\<num\>couple\</num\> of \<measure type=\"TIME\"
-unit=\"week\"\>weeks\</measure\>\</measure\>]{.title-ref}). See issue
+Determiners are left outside of the measure:
+
+``` xml
+a <measure type="value"><num>couple</num> of <measure type="TIME" unit="week">weeks</measure></measure>
+```
+
+See issue
 [#34](https://github.com/kermitt2/grobid-quantities/issues/34)
 
 #### X-fold
 
-Quantifiers like `two-fold`, `sevenfold` meaning \"two times/part\",
-\"seven times/part\" are annotated, to capture the full expression of
-quantity including this notion of \"part\":
+Quantifiers like `two-fold`, `sevenfold` meaning "two times/part",
+"seven times/part" are annotated, to capture the full expression of
+quantity including this notion of "part":
 
 ``` xml
 allowing a <measure type="value"><num>sevenfold</num></measure> compaction of the length
@@ -405,8 +409,8 @@ See issue [#38](https://github.com/kermitt2/grobid-quantities/issues/38)
 
 #### Numbers which seems to be only tags but are in fact quantifying
 
-For example expressions like [at day 21]{.title-ref} or [between day 56
-and day 91]{.title-ref}, which are really quantifying and for which
+For example expressions like `at day 21` or `between day 56 and day 91`,
+which are really quantifying and for which
 range queries can be expressed.
 
 #### OCR errors
@@ -533,9 +537,8 @@ scope. See issue
 
 #### Some sequences not annotated (not commented)
 
-[Markers, call-out, section number, numerical bullet points,
-identifiers, index, reference expressions, formula
-parameters]{.title-ref}
+Markers, call-out, section number, numerical bullet points, identifiers,
+index, reference expressions and formula parameters.
 
 Examples:
 
@@ -737,11 +740,14 @@ This labels are combined to recognise this type of values:
 
   The `<base>` and `<pow>` should contains only values. Additional
   markers (like `x`, `^`, `x`) should be left out. The `<base>` label
-  should contains expression of the \"base\", usually `10` but could
+  should contains expression of the "base", usually `10` but could
   be set to different values.
 
-  For example: :: \<value\>\<number\>1\</number\> ×
-  \<base\>10\</base\> \<pow\>−7\</pow\>\</value\>
+  For example:
+
+  ``` xml
+  <value><number>1</number> × <base>10</base> <pow>−7</pow></value>
+  ```
 
 - Euler's number based expressions, discussed in [#8](https://github.com/kermitt2/grobid-quantities/issues/8).
   Example: 
@@ -753,7 +759,7 @@ This labels are combined to recognise this type of values:
 
 - time and date expressions, discussed in [#12](https://github.com/kermitt2/grobid-quantities/issues/12)
   ``` xml
-  <value><time>2001 August</time></value\>
+  <value><time>2001 August</time></value>
   ```
 
 ## Quantified objects CRF model {#quantified-object-model}
@@ -773,15 +779,20 @@ used for a CRF model to replace the current implementation.
 In the training data are identified the measurement (and their type) and
 the quantified object.
 
-For example: :: \<p\>A mixture of 10kg of silicon nitride powder.\</p\>
+For example:
 
-can be annotated as: :: \<p\>A mixtured of \<measure type=\"value\"
-ptr=\"#1235324324321\"\>10kg\</measure\> of \<quantifiedObject
-id=\"1235324324321\"\>silicon nitride powder\</quantified
-Object\>.\</p\>
+``` xml
+<p>A mixture of 10kg of silicon nitride powder.</p>
+```
+
+can be annotated as:
+
+``` xml
+<p>A mixture of <measure type="value" ptr="#1235324324321">10kg</measure> of <quantifiedObject id="1235324324321">silicon nitride powder</quantifiedObject>.</p>
+```
 
 The quantified object is identified by its ID and linked to the measure
-via the attribute [ptr=\"#ID\"]{.title-ref}.
+via the attribute `ptr="#ID"`.
 
 > :information_source: This implementation allows the linking of objects directly attached on the left or right of the measurement, for the time being far entities
 are not supported.
@@ -814,4 +825,4 @@ See issue [#79](https://github.com/lfoppiano/grobid-quantities/issues/79)
 
 Annotating the quantifiedObject is a complicated task, because it
 requires a clear definition to avoid misunderstanding. Firstly the
-question each annotator should ask is \"What is being measured?\".
+question each annotator should ask is "What is being measured?".

--- a/doc/references.md
+++ b/doc/references.md
@@ -4,8 +4,10 @@
 
 If you want to cite this work, please simply refer to the github project, with optionally the [Software Heritage](https://www.softwareheritage.org/) project-level permanent
 
+identifier:
+
 ```
-identifier: :: grobid-quantities (2015-2025)
+grobid-quantities (2015-2025)
 <https://github.com/kermitt2/grobid-quantities>,
 swh:1:dir:dbf9ee55889563779a09b16f9c451165ba62b6d7
 ```

--- a/doc/training.md
+++ b/doc/training.md
@@ -5,8 +5,7 @@ See [guidelines](guidelines.md) for detailed explanations and examples.
 
 ## Generation of training data
 
-Training data generation works the same as in GROBID, with executable name `createTrainingQuantities`, for example::
-
+Training data generation works the same as in GROBID, with executable name `createTrainingQuantities`, for example:
 ```shell
  java -Djava.library.path=../grobid-home/lib/{arch}/:{MY_VIRTUAL_ENV}/lib:{MY_VIRTUAL_ENV}/lib/python3.9/site-packages/jep -jar build/libs/grobid-quantities-{version}-onejar.jar trainingGeneration -dIn ~/grobid/grobid-quantities/src/test/resources/ -dOut ~/test/ resources/config/config.yml
 ```
@@ -37,7 +36,7 @@ The training can be invoked using gradle or via the command using the dropwizard
 
 The trainer uses all the available training data from `resouces/dataset/quantities/corpus`.
 
-> :warning: We provide already both training and evaluation corpora, which should be used to evaluate. Given the small size of the corpus, we recommend to combine [corpus]{.title-ref} and [evaluation]{.title-ref} only for training the final model.
+> :warning: We provide already both training and evaluation corpora, which should be used to evaluate. Given the small size of the corpus, we recommend to combine `corpus` and `evaluation` only for training the final model.
 
 
 Via Gradle: 
@@ -123,8 +122,7 @@ The holdout evaluation train the model and run the evaluation against a fixed se
 
 The training data is taken from `resouces/dataset/MODEL_NAME/corpus` and  the evaluation data is taken from `resouces/dataset/MODEL_NAME/evaluation`.
 
-The command to run the holdout evauation is:::
-
+The command to run the holdout evaluation is:
 ```shell
 java -Djava.library.path=../grobid-home/lib/{arch}/:{MY_VIRTUAL_ENV}/lib:{MY_VIRTUAL_ENV}/lib/python3.9/site-packages/jep -jar build/libs/grobid-quantities-{version}-onejar.jar training -m model_name -a holdout resources/config/config.yml
 ```
@@ -144,8 +142,7 @@ java -Djava.library.path=../grobid-home/lib/{arch}/:{MY_VIRTUAL_ENV}/lib:{MY_VIR
 The N-fold cross-validation perform the training and evaluation N times, partition the training data in N sets and using each set for evaluation while training with the rest. More detailed explanation [here](https://en.wikipedia.org/wiki/Cross-validation_(statistics)). 
 The evaluation will then give the average scores over these n models (against test set) and for the best model which will be saved.
 
-The command to run the n-fold cross-validation with N folds is the following:::
-
+The command to run the n-fold cross-validation with N folds is the following:
 ```shell
 java -Djava.library.path=../grobid-home/lib/{arch}/:{MY_VIRTUAL_ENV}/lib:{MY_VIRTUAL_ENV}/lib/python3.9/site-packages/jep -jar build/libs/grobid-quantities-{version}-onejar.jar training -m model_name -a nfold \--fold-count N resources/config/config.yml
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.9.0-SNAPSHOT
+version=0.9.1-SNAPSHOT
 
 # Kotlin 2.0.21 K2 compiler workaround: IrConstDeclarationAnnotationTransformer
 # recursively visits the IR tree and overflows the default ~512KB-1MB JVM thread


### PR DESCRIPTION
Changes: 
- Guidelines update
- Fix leftover from restructureText in documentation
- Fix changelog and migration plan for the version 0.9.1 (to be released)