### PR TITLE
build: make the integration task actually run the integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -290,7 +290,14 @@ run {
 }
 
 task integration(type: Test) {
+    // a Test task created by hand inherits nothing from the java plugin's `test`: without these
+    // two it has no classes to run and reports success on 0 tests
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
     include '**'
+
+    useJUnitPlatform()
 
     maxHeapSize = "1024m"
 


### PR DESCRIPTION
`./gradlew integration` reported BUILD SUCCESSFUL and produced no test report at all: a Test task created by hand inherits neither testClassesDirs nor classpath from the java plugin's `test`, so it had nothing to run and passed on 0 tests. Six *IntegrationTest classes are excluded from `test` on the assumption that this task covers them, and none of them had ever run through it.

Set both properties, and call useJUnitPlatform() as `test` does, so the JUnit 5 tests among them are discovered rather than silently skipped.

  before   0 tests, BUILD SUCCESSFUL, no report produced
  after  219 tests (154 unit + 65 integration), 7 failing

The 7 failures are environmental, not regressions: QuantityParser and ValueParser integration tests initialise through GrobidProperties, which resolves grobid-home to ../grobid-home regardless of the grobidHome set in config-test.yml, and that directory here holds only models/ with no config/grobid.yaml. They need a complete grobid-home beside the repository. The other 58 integration tests pass - UnitParser 25, QuantityLexicon 21, QuantityNormalizer 9, TextParser 1.
